### PR TITLE
Fixing wrong manifest name endings

### DIFF
--- a/XogarLib/SimpleValveGameParser.cs
+++ b/XogarLib/SimpleValveGameParser.cs
@@ -96,7 +96,7 @@ namespace XogarLib
 
                     foreach (var manifestFile in manifestFiles)
                     {
-                        if (manifestFile.Contains("appmanifest_"))
+                        if (manifestFile.Contains("appmanifest_") && manifestFile.EndsWith(".acf"))
                         {
                             string[] splitManifest = manifestFile.Split(new string[] {"appmanifest_"},
                                 StringSplitOptions.None);


### PR DESCRIPTION
Wrong file name endings caused the programm to kill itself becaus the exception from the Int64.parse was not caught. But since these names are invalid just check for correct name ending.

To test just try appending/copying a manifest file to something like "appmanifest_123456.acf.bak"